### PR TITLE
dsv is deprecated in favor of d3-dsv.

### DIFF
--- a/bin/dbf2dsv
+++ b/bin/dbf2dsv
@@ -4,7 +4,7 @@ var rw = require('rw'),
     minimist = require('minimist'),
     queue = require('queue-async'),
     dbf = require('shapefile/dbf'),
-    dsv = require('dsv');
+    dsv = require('d3-dsv');
 
 var argv = minimist(process.argv.slice(2), {
   alias: {
@@ -19,7 +19,7 @@ var argv = minimist(process.argv.slice(2), {
 
 argv.d = argv.d.replace(/\\t/, '\t'); // Make --delimiter="\t" work
 var input = argv._[0] || '/dev/stdin';
-var formatRows = dsv(argv.d).formatRows;
+var formatRows = dsv.dsv(argv.d).formatRows;
 var reader = dbf.reader(input);
 
 var rows = [];

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "tsv"
   ],
   "author": "Jeremy Stucki",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/herrstucki/dbf2dsv/issues"
   },
   "homepage": "https://github.com/herrstucki/dbf2dsv",
   "dependencies": {
-    "dsv": "0.0.3",
+    "d3-dsv": "^0.1.5",
     "minimist": "^0.2.0",
     "queue-async": "^1.0.7",
     "rw": "^0.1.1",


### PR DESCRIPTION
- Replace `dsv` in favor of `d3-dsv`.
- Update the licence field to avoid warning from NPM.
